### PR TITLE
[should-fetch-range] Add fix for invalid pages

### DIFF
--- a/src/list/should-fetch-range.js
+++ b/src/list/should-fetch-range.js
@@ -1,12 +1,21 @@
 import isExpired from '../status/is-expired';
 import isOK from '../status/is-ok';
 import _entries from './_entries';
+import _list from './_list';
+import _total from './_total';
 
 export default
 function shouldFetchRange(root, listName, start, end) {
+    const list = _list(root, listName);
+    const total = _total(list);
+
+    end = Math.min(end, total - 1); // Limit end to the number of entries
+    end = Math.max(0, end); // Prevent negative numbers (when total == 0)
+
     const entries = _entries(root, listName, start, end);
 
     return entries.reduce((r, entry) => {
-        return r || isExpired(entry) || !isOK(entry);
+        const hasId = entry && entry.id !== null && typeof entry.id !== 'undefined';
+        return r || !hasId || isExpired(entry) || !isOK(entry);
     }, false);
 }

--- a/test/list/should-fetch-range.js
+++ b/test/list/should-fetch-range.js
@@ -1,7 +1,9 @@
 import assert from 'assert';
 
 import add from '../../src/resource/add';
+import options from '../../src/list/options';
 import addRange from '../../src/list/add-range';
+import addPage from '../../src/list/add-page';
 
 import shouldFetchRange from '../../src/list/should-fetch-range';
 
@@ -32,5 +34,16 @@ describe('# shouldFetchRange(root, list, start, end)', () => {
         const fetch = shouldFetchRange(state, 'all', 0, 3);
 
         assert.equal(fetch, false);
+    });
+
+    it('Should detect a fetch for invalid pages', () => {
+        let state = add(null, 0, { id: 0 });
+        state = options(state, { total: 4 });
+
+        // Calls like this should include pageSize as option
+        state = addPage(state, 'all', 1, [ 0 ]);
+
+        const fetch = shouldFetchRange(state, 'all', 0, 3);
+        assert.equal(fetch, true);
     });
 });


### PR DESCRIPTION
Add fix for pages containing `null` ids due to
calls to `addPage` without the correct `pageSize` option set.