### PR TITLE
[throttle-all][throttled-dispatch] Remove throttleAll

### DIFF
--- a/src/vuex/get-page.js
+++ b/src/vuex/get-page.js
@@ -4,6 +4,7 @@ import _omit from 'lodash/omit';
 import shouldFetchPage from '../list/should-fetch-page';
 import fetchPage from '../list/page';
 
+import { wrapDispatch } from './throttled-dispatch';
 import { updateListHash } from './_state-helper';
 import _selectors from './_selectors';
 import _compact from './_compact';
@@ -45,15 +46,15 @@ function getPage(pageSelector, listName, options = {}) {
         const page =  getSelection(this, opts) || 1;
         const listName = getListName(this, opts);
         const store = _get(this, storeName);
-        const { state, dispatch } = store;
         const hash = getHash(_omit(opts, HASH_IGNORE));
+        const dispatch = wrapDispatch(store.dispatch);
 
         if (page < 1)
             throw new Error('page must be greater than 0');
 
         updateListHash(store, namespace, listName, hash);
 
-        const root = getRoot(state, namespace);
+        const root = getRoot(store.state, namespace);
         if (shouldFetchPage(root, listName, page, opts))
             dispatch(fetch, { listName, page, ...opts });
 

--- a/src/vuex/get-range.js
+++ b/src/vuex/get-range.js
@@ -6,6 +6,7 @@ import getRoot from './get-root';
 import _compact from './_compact';
 import _selectors from './_selectors';
 import { updateListHash } from './_state-helper';
+import { wrapDispatch } from './throttled-dispatch';
 
 const rangeDefaults = {
     namespace: null,
@@ -37,13 +38,12 @@ function getRange(rangeSelector, listName, options = {}) {
         const { start = 0, end = 9 } = getSelection(this, opts) || {};
 
         const store = _get(this, storeName);
-        const { state, dispatch } = store;
         const hash = getHash(opts);
-
+        const dispatch = wrapDispatch(store.dispatch);
 
         updateListHash(store, namespace, listName, hash);
 
-        const root = getRoot(state, namespace);
+        const root = getRoot(store.state, namespace);
         if (shouldFetchRange(root, listName, start, end))
             dispatch(fetch, { listName, start, end, ...opts });
 

--- a/src/vuex/get-resource.js
+++ b/src/vuex/get-resource.js
@@ -1,7 +1,8 @@
 import _get from 'lodash/get';
 
-import resource from '../resource';
+import { wrapDispatch } from './throttled-dispatch';
 import shouldFetch from '../resource/should-fetch';
+import resource from '../resource';
 import getRoot from './get-root';
 
 const resourceDefaults = {
@@ -29,11 +30,12 @@ function getResource(selector, options) {
         fetch = `${namespace}/${fetch}`;
 
     return function() {
-        const { state, dispatch } = _get(this, storeName);
-        const opts = getParams(this);
         const id =  getId(this);
+        const opts = getParams(this);
+        const store = _get(this, storeName);
+        const dispatch = wrapDispatch(store.dispatch);
 
-        const root = getRoot(state, namespace);
+        const root = getRoot(store.state, namespace);
 
         if (shouldFetch(root, id))
             dispatch(fetch, { id, ...opts });

--- a/src/vuex/index.js
+++ b/src/vuex/index.js
@@ -2,5 +2,6 @@ export getResource from './get-resource';
 export getRange from './get-range';
 export getPage from './get-page';
 
+export { wrapDispatch } from './throttled-dispatch';
 export throttleAll from './throttle-all';
 export apply from './apply';

--- a/src/vuex/throttle-all.js
+++ b/src/vuex/throttle-all.js
@@ -1,40 +1,11 @@
-import _mapValues from 'lodash/mapValues';
-import _debounce from 'lodash/debounce';
-
-import hash from 'hash-it';
-
-function __debounce(func, timeout, opts) {
-    const cache = {};
-
-    return function(...args) {
-        const key = opts.id(...args);
-
-        if (!cache[key])
-            cache[key] = _debounce(func, timeout, opts);
-
-        return cache[key](...args);
-    };
-}
-
-function wrapMethod(method) {
-    return __debounce(method, 500, {
-        leading: true,
-        id: (ctx, ...args) => hash(args)
-    });
-}
+let isFirst = true;
 
 export default
 function throttleAll(methods) {
-    return _mapValues(methods, method => {
-        if (typeof method === 'function')
-            return wrapMethod(method);
-
-        if (typeof method !== 'object' || typeof method.handler !== 'function')
-            return method;
-
-        return {
-            ...method,
-            handler: wrapMethod(method.handler)
-        };
-    });
+    if (isFirst) {
+        isFirst = false;
+        // eslint-disable-next-line no-console
+        console.warn('[rest-store] throttleAll is no longer required, please remove it');
+    }
+    return methods;
 }

--- a/src/vuex/throttled-dispatch.js
+++ b/src/vuex/throttled-dispatch.js
@@ -1,0 +1,32 @@
+import _debounce from 'lodash/debounce';
+import hash from 'hash-it';
+
+const throttled = new Map();
+
+function __debounce(func, timeout, opts) {
+    const cache = {};
+
+    return function(...args) {
+        const key = opts.id(...args);
+
+        if (!cache[key])
+            cache[key] = _debounce(func, timeout, opts);
+
+        return (0, cache[key])(...args);
+    };
+}
+
+export
+function wrapDispatch(dispatch) {
+    if (throttled.has(dispatch))
+        return throttled.get(dispatch);
+
+    const wrapper = __debounce(dispatch, 1000, {
+        leading: true,
+        id: (...args) => hash(args)
+    });
+
+    throttled.set(dispatch, wrapper);
+
+    return wrapper;
+}

--- a/test/vuex/throttle-all.js
+++ b/test/vuex/throttle-all.js
@@ -5,65 +5,14 @@ import throttleAll from '../../src/vuex/throttle-all';
 
 describe('Vuex.throttleAll(obj)', () => {
 
-    it('Should limit the times a method can be called', () => {
-        const obj = {
-            test: sinon.spy()
-        };
+    it('Should warn user about usage', () => {
+        const obj = {};
+        const spy = sinon.stub(console, 'warn');
 
-        const target = throttleAll(obj);
+        throttleAll(obj);
+        throttleAll(obj);
 
-        target.test();
-        target.test();
-        target.test();
-
-        assert.equal(obj.test.callCount, 1);
-    });
-
-    it('Should limit the times a method can be called with the same args', () => {
-        const obj = {
-            test: sinon.spy()
-        };
-
-        const target = throttleAll(obj);
-
-        target.test({}, 1);
-        target.test({}, 2);
-        target.test({}, 1);
-
-        assert.equal(obj.test.callCount, 2);
-    });
-
-    // https://vuex.vuejs.org/guide/modules.html#register-global-action-in-namespaced-modules
-    it('Should support objects with handler method', () => {
-        const obj = {
-            test: {
-                root: true,
-                handler: sinon.spy()
-            }
-        };
-
-        const target = throttleAll(obj);
-
-        assert.equal(typeof target.test, 'object');
-        assert.equal(typeof target.test.handler, 'function');
-
-        const a = 'a';
-        const b = 'b';
-
-        target.test.handler({}, { a, b });
-        target.test.handler({}, { b, a });
-
-        assert.equal(obj.test.handler.callCount, 1);
-    });
-
-    it('Should not touch unsupported properties', () => {
-        const obj = { prop: {} };
-
-        const target = throttleAll(obj);
-
-        assert.strictEqual(obj.prop, target.prop);
-        assert.equal(typeof obj.prop, 'object');
-        assert.equal(typeof obj.prop.handler, 'undefined');
+        assert.equal(spy.callCount, 1);
     });
 
 });

--- a/test/vuex/throttled-dispatch.js
+++ b/test/vuex/throttled-dispatch.js
@@ -1,0 +1,64 @@
+import assert from 'assert';
+import sinon from 'sinon';
+
+import { wrapDispatch } from '../../src/vuex/throttled-dispatch';
+
+describe('Vuex._throttledDispatch()', () => {
+
+    it('Should limit the times an action can be called', () => {
+        const dispatch = sinon.spy();
+        const wrapped = wrapDispatch(dispatch);
+
+        wrapped('test');
+        assert.equal(dispatch.callCount, 1);
+
+        wrapped('test');
+        wrapped('test');
+        wrapped('test');
+        assert.equal(dispatch.callCount, 1);
+    });
+
+    it('Should limit the times an action can be called with the same args', () => {
+        const dispatch = sinon.spy();
+        const wrapped = wrapDispatch(dispatch);
+
+        wrapped('test', { hello: 'world' });
+        assert.equal(dispatch.callCount, 1);
+
+        wrapped('test', { hello: 'world' });
+        wrapped('test', { hello: 'world' });
+        wrapped('test', { hello: 'world' });
+        assert.equal(dispatch.callCount, 1);
+    });
+
+    it('Should call the method multiple times with different arguments', () => {
+        const dispatch = sinon.spy();
+        const wrapped = wrapDispatch(dispatch);
+
+        wrapped('test', { hello: 'world' });
+        assert.equal(dispatch.callCount, 1);
+
+        wrapped('test', { hello: 'planet' });
+        wrapped('test', { hello: 'world' });
+        wrapped('test', { hello: 'world' });
+        assert.equal(dispatch.callCount, 2);
+    });
+
+    it('Should return the same wrapper for the same dispatch method', () => {
+        const dispatch = sinon.spy();
+        const wrapped1 = wrapDispatch(dispatch);
+        const wrapped2 = wrapDispatch(dispatch);
+
+        assert.strictEqual(wrapped1, wrapped2);
+    });
+
+    it('Should return different wrappers for different dispatch methods', () => {
+        const dispatch1 = sinon.spy();
+        const dispatch2 = sinon.spy();
+        const wrapped1 = wrapDispatch(dispatch1);
+        const wrapped2 = wrapDispatch(dispatch2);
+
+        assert.notStrictEqual(wrapped1, wrapped2);
+    });
+
+});


### PR DESCRIPTION
Replaces throttleAll applied to all actions globally by a transparent
throttle on any action dispatched by `get-page`, `get-range` or
`get-resource`.