### PR TITLE
[vuex][resource] add support for placeholder values

### DIFF
--- a/src/vuex/get-resource.js
+++ b/src/vuex/get-resource.js
@@ -16,7 +16,7 @@ export default
 function getResource(selector, options) {
     options = { ...resourceDefaults, ...options };
 
-    const { storeName, params, condition } = options;
+    const { storeName, params, condition, placeholder = null } = options;
 
     const getId = typeof selector === 'function' ?
         selector : (cmp) => _get(cmp, selector);
@@ -42,6 +42,11 @@ function getResource(selector, options) {
         if (allowFetch && shouldFetch(root, id))
             dispatch(fetch, { id, ...opts });
 
-        return resource(root, id);
+        const value = resource(root, id);
+
+        if (value === null)
+            return placeholder;
+
+        return value;
     };
 }


### PR DESCRIPTION
`Vuex.getResource` now supports the additional `placeholder` option which can be set to any value that should be returned as long as there is no entry in the store.