### PR TITLE
[transformable] allow vuex results to be transformed

### DIFF
--- a/src/vuex/_transformable.js
+++ b/src/vuex/_transformable.js
@@ -1,10 +1,26 @@
+import { is, isNil } from '../utils';
+import { ENTRY } from '../constants';
+
+function getEntry(v) {
+    return v && (is(v, 'symbol') ? v : v[ENTRY]);
+}
+
 export default
 function transformable(fn) {
     const transformations = [];
 
     function exec() {
         return transformations.reduce((r, f) => {
-            return f.call(this, r);
+            const entry = getEntry(r);
+            const result = f.call(this, r);
+
+            if (entry && isNil(result))
+                return ENTRY;
+
+            if (entry && result)
+                result[ENTRY] = entry;
+
+            return result;
         }, fn.call(this));
     }
 

--- a/src/vuex/_transformable.js
+++ b/src/vuex/_transformable.js
@@ -1,0 +1,20 @@
+export default
+function transformable(fn) {
+    const transformations = [];
+
+    function exec() {
+        return transformations.reduce((r, f) => {
+            return f.call(this, r);
+        }, fn.call(this));
+    }
+
+    function transform(t) {
+        transformations.push(t);
+        return exec;
+    }
+
+    fn.transform = transform;
+    exec.transform = transform;
+
+    return fn;
+}

--- a/src/vuex/get-option.js
+++ b/src/vuex/get-option.js
@@ -1,13 +1,14 @@
 import _get from 'lodash/get';
 import _getList from './_get-list';
+import _transformable from './_transformable';
 
 export default
 function getOption(listName, option, options = {}) {
     const getList = _getList(listName, options);
 
-    return function() {
+    return _transformable(function() {
         const list = getList(this);
 
         return _get(list, option);
-    };
+    });
 }

--- a/src/vuex/get-page-count.js
+++ b/src/vuex/get-page-count.js
@@ -1,5 +1,6 @@
 import _getList from './_get-list';
 import _selectors from './_selectors';
+import _transformable from './_transformable';
 
 import _total from '../list/_total';
 import _pageSize from '../list/_page-size';
@@ -9,12 +10,12 @@ function getTotal(listName, options = {}) {
     const getList = _getList(listName, options);
     const { getParams } = _selectors('option', { ...options, listName });
 
-    return function() {
+    return _transformable(function() {
         const list = getList(this);
         const opts = getParams(this);
         const total = _total(list);
         const pageSize = _pageSize(list, opts);
 
         return Math.ceil(total / pageSize);
-    };
+    });
 }

--- a/src/vuex/get-page.js
+++ b/src/vuex/get-page.js
@@ -6,6 +6,7 @@ import fetchPage from '../list/page';
 
 import { wrapDispatch } from './throttled-dispatch';
 import { updateListHash } from './_state-helper';
+import _transformable from './_transformable';
 import _selectors from './_selectors';
 import _compact from './_compact';
 import getRoot from './get-root';
@@ -42,7 +43,7 @@ function getPage(pageSelector, listName, options = {}) {
     if (namespace && typeof fetch === 'string')
         fetch = `${namespace}/${fetch}`;
 
-    return function() {
+    return _transformable(function() {
         const opts = getParams(this);
         const page =  getSelection(this, opts) || 1;
         const listName = getListName(this, opts);
@@ -62,5 +63,5 @@ function getPage(pageSelector, listName, options = {}) {
 
         const entries = fetchPage(root, listName, page, opts);
         return _compact(entries);
-    };
+    });
 }

--- a/src/vuex/get-range.js
+++ b/src/vuex/get-range.js
@@ -1,6 +1,7 @@
 import _get from 'lodash/get';
 
 import shouldFetchRange from '../list/should-fetch-range';
+import _transformable from './_transformable';
 import fetchRange from '../list/range';
 import getRoot from './get-root';
 import _compact from './_compact';
@@ -33,7 +34,7 @@ function getRange(rangeSelector, listName, options = {}) {
     if (namespace && typeof fetch === 'string')
         fetch = `${namespace}/${fetch}`;
 
-    return function() {
+    return _transformable(function() {
         const opts = getParams(this);
         const listName = getListName(this, opts);
         const { start = 0, end = 9 } = getSelection(this, opts) || {};
@@ -51,5 +52,5 @@ function getRange(rangeSelector, listName, options = {}) {
 
         const entries = fetchRange(root, listName, start, end, opts);
         return _compact(entries);
-    };
+    });
 }

--- a/src/vuex/get-resource.js
+++ b/src/vuex/get-resource.js
@@ -2,6 +2,7 @@ import _get from 'lodash/get';
 
 import { wrapDispatch } from './throttled-dispatch';
 import shouldFetch from '../resource/should-fetch';
+import _transformable from './_transformable';
 import resource from '../resource';
 import getRoot from './get-root';
 
@@ -30,7 +31,7 @@ function getResource(selector, options) {
     if (namespace && typeof fetch === 'string')
         fetch = `${namespace}/${fetch}`;
 
-    return function() {
+    return _transformable(function() {
         const id =  getId(this);
         const opts = getParams(this);
         const allowFetch = condition(this, opts);
@@ -48,5 +49,5 @@ function getResource(selector, options) {
             return placeholder;
 
         return value;
-    };
+    });
 }

--- a/src/vuex/get-total.js
+++ b/src/vuex/get-total.js
@@ -1,13 +1,14 @@
 import _getList from './_get-list';
 import _total from '../list/_total';
+import _transformable from './_transformable';
 
 export default
 function getTotal(listName, options = {}) {
     const getList = _getList(listName, options);
 
-    return function() {
+    return _transformable(function() {
         const list = getList(this);
 
         return _total(list);
-    };
+    });
 }

--- a/test/vuex/_transformable.js
+++ b/test/vuex/_transformable.js
@@ -1,0 +1,136 @@
+import sinon from 'sinon';
+import assert from 'assert';
+
+import getPage from '../../src/vuex/get-page';
+import getRange from '../../src/vuex/get-range';
+import getTotal from '../../src/vuex/get-total';
+import getResource from '../../src/vuex/get-resource';
+
+import { ENTRY } from '../../src/constants';
+import { attach, addPage, add, options } from '../../src';
+
+import { makeStore } from './util';
+
+describe('Vuex.*.transform', () => {
+
+    let $store;
+
+    beforeEach(() => {
+        let state = attach();
+        state = add(state, 1, { id: 1 });
+        state = add(state, 2, { id: 2 });
+        state = add(state, 3, { id: 3 });
+        state = addPage(state, 'all', 1, [ 1, 2, 3 ]);
+        state = options(state, 'all', { total: 3 });
+
+        $store = makeStore({
+            state
+        });
+    });
+
+    it('getPage should have support', () => {
+        const transform = sinon.spy(users => {
+            return users.filter(u => u.id == 2);
+        });
+        const cmp = {
+            $store,
+
+            page: 1,
+            users: getPage('page', 'all')
+                .transform(transform)
+        };
+
+        const result = cmp.users();
+
+        assert.equal(transform.callCount, 1);
+        assert.equal(result.length, 1);
+        assert.equal(result[0].id, 2);
+    });
+
+    it('getRange should have support', () => {
+        const transform = sinon.spy(users => {
+            return users.filter(u => u.id == 2);
+        });
+        const cmp = {
+            $store,
+
+            range: { start: 0, end: 3 },
+            users: getRange('range', 'all')
+                .transform(transform)
+        };
+
+        const result = cmp.users();
+
+        assert.equal(transform.callCount, 1);
+        assert.equal(result.length, 1);
+        assert.equal(result[0].id, 2);
+    });
+
+    it('getResource should have support', () => {
+        const transform = sinon.spy(user => ({ ...user, name: 'test' }));
+        const cmp = {
+            $store,
+
+            resourceId: 2,
+            user: getResource('resourceId').transform(transform)
+        };
+
+        const result = cmp.user();
+
+        assert.equal(transform.callCount, 1);
+        assert.equal(result.id, 2);
+        assert.equal(result.name, 'test');
+    });
+
+    it('getTotal should have support', () => {
+        const transform = sinon.spy(total => total - 1);
+        const cmp = {
+            $store,
+
+            total: getTotal('all').transform(transform)
+        };
+
+        const result = cmp.total();
+
+        assert.equal(transform.callCount, 1);
+        assert.equal(result, 2);
+    });
+
+    it('should support multiple transforms', () => {
+        const transform1 = sinon.spy(user => ({ ...user, name: 'test' }));
+        const transform2 = sinon.spy(user => ({ ...user, username: 'test321' }));
+        const cmp = {
+            $store,
+
+            resourceId: 2,
+            user: getResource('resourceId')
+                .transform(transform1)
+                .transform(transform2)
+        };
+
+        const result = cmp.user();
+
+        assert.equal(transform1.callCount, 1);
+        assert.equal(transform2.callCount, 1);
+        assert.equal(result.id, 2);
+        assert.equal(result.name, 'test');
+        assert.equal(result.username, 'test321');
+    });
+
+    it('should preserve response state', () => {
+        const transform = sinon.spy(users => users.filter(u => !!u));
+        const cmp = {
+            $store,
+
+            page: 1,
+            users: getPage('page', 'all').transform(transform)
+        };
+
+        const result = cmp.users();
+
+        assert.equal(transform.callCount, 1);
+        assert(result[ENTRY]);
+        assert.equal(result[ENTRY].length, 3);
+    });
+
+});


### PR DESCRIPTION
Allows manipulation of computed results without having to resort to extra computed properties.

You can now change any of the `getPage / getRange / getResource / getTotal` result values by chaining the `transform` method as many times as you like.

**Example**
```js
getPage('page', 'all')
  .transform(filterFunction)
  .transform(anotherFilterFunction)
```

**previously**
```js
export default {
  data() {
    return { page: 1 };
  },
  computed: {
    users: getPage('page', 'all'),
    onlineUsers() {
      return users.filter(u => u.online);
    }
  }
}
```

**now**
```js
export default {
  data() {
    return { page: 1 };
  },
  computed: {
    onlineUsers: getPage('page', 'all')
      .transform(users => users.filter(u => u.online))
  }
}
```