### PR TITLE
[list] verify resource state in entries

### DIFF
--- a/src/list/_entries.js
+++ b/src/list/_entries.js
@@ -1,6 +1,16 @@
 import _total from './_total';
 import _list from './_list';
 import _expand from './_expand';
+import isState from '../status/is-state';
+import { OK } from '../constants';
+
+function _resourceState(root, id) {
+    if (!root || !root.resources || !root.resources[id])
+        return null;
+
+    const entry = root.resources[id];
+    return entry.state;
+}
 
 export default
 function _entries(root, listName, start, end) {
@@ -16,7 +26,16 @@ function _entries(root, listName, start, end) {
 
     const count = end - start;
     const result = entries
-        .slice(start, end);
+        .slice(start, end)
+        .map(entry => {
+            if (!isState(entry, OK))
+                return entry;
+
+            const state = _resourceState(root, entry && entry.id);
+            if (!state) return null;
+
+            return { ...entry, state };
+        });
 
     if (result.length == count)
         return result;

--- a/test/list/range.js
+++ b/test/list/range.js
@@ -1,7 +1,8 @@
 import assert from 'assert';
 
-import { ENTRY } from '../../src/constants';
+import { ENTRY, OK, EXPIRED } from '../../src/constants';
 import range from '../../src/list/range';
+import isOK from '../../src/status/is-ok';
 
 describe('# range(root, list, start, end)', () => {
 
@@ -119,5 +120,31 @@ describe('# range(root, list, start, end)', () => {
 
         assert(Array.isArray(result[ENTRY].entries), 'entries is an array');
         assert.equal(result[ENTRY].total, 0);
+    });
+
+    it('Should verify resource status', () => {
+        const state = {
+            resources: {
+                1: { data: { id: 1 }, state: OK },
+                2: { data: { id: 2 }, state: EXPIRED }
+            },
+            list: {
+                all: {
+                    total: 10,
+                    entries: [
+                        { id: 1, state: OK },
+                        { id: 2, state: OK }
+                    ]
+                }
+            }
+        };
+
+        const result = range(state, 'all', 0, 1);
+        assert.deepEqual(result, [
+            { id: 1 },
+            { id: 2 }
+        ]);
+
+        assert(!isOK(result), 'List is not in OK state');
     });
 });


### PR DESCRIPTION
Verify that the state of the list entry matches that of the resource it
references. This would prevent a list from automatically updating when a
resource was changed or expired.