### PR TITLE
[status] add checks for pending and viewable

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -7,6 +7,8 @@ export isError from './status/is-error';
 export isLoading from './status/is-loading';
 export isExpired from './status/is-expired';
 export isMissing from './status/is-missing';
+export isPending from './status/is-pending';
+export isViewable from './status/is-viewable';
 
 // Should fetch
 export shouldFetch from './resource/should-fetch';

--- a/src/status/is-pending.js
+++ b/src/status/is-pending.js
@@ -1,0 +1,7 @@
+import isOK from './is-ok';
+import isLoading from './is-loading';
+
+export default
+function isPending(obj) {
+    return !isOK(obj) && isLoading(obj);
+}

--- a/src/status/is-viewable.js
+++ b/src/status/is-viewable.js
@@ -1,0 +1,6 @@
+import isPending from './is-pending';
+
+export default
+function isViewable(obj) {
+    return !isPending(obj);
+}

--- a/test/status/is-pending.js
+++ b/test/status/is-pending.js
@@ -1,0 +1,35 @@
+import assert from 'assert';
+
+import get from '../../src/resource';
+import add from '../../src/resource/add';
+import loading from '../../src/resource/loading';
+
+import isPending from '../../src/status/is-pending';
+
+describe('# is-pending', () => {
+
+    it('Should detect pending state', () => {
+        const state = loading(null, 1);
+        const res = get(state, 1);
+
+        assert(isPending(res), 'resource is pending');
+    });
+
+    it('Should detect non-pending state', () => {
+        const state = add(null, 1, {});
+        const res = get(state, 1);
+
+        assert(!isPending(res), 'resource is not pending');
+    });
+
+    it('Should detect non-pending state', () => {
+        let state = null;
+        state = add(state, 1, {});
+        state = loading(state, 1);
+
+        const res = get(state, 1);
+
+        assert(!isPending(res), 'resource is not pending');
+    });
+
+});

--- a/test/status/is-viewable.js
+++ b/test/status/is-viewable.js
@@ -1,0 +1,35 @@
+import assert from 'assert';
+
+import get from '../../src/resource';
+import add from '../../src/resource/add';
+import loading from '../../src/resource/loading';
+
+import isViewable from '../../src/status/is-viewable';
+
+describe('# is-viewable', () => {
+
+    it('Should detect non-viewable state', () => {
+        const state = loading(null, 1);
+        const res = get(state, 1);
+
+        assert(!isViewable(res), 'resource is not viewable');
+    });
+
+    it('Should detect viewable state', () => {
+        const state = add(null, 1, {});
+        const res = get(state, 1);
+
+        assert(isViewable(res), 'resource is viewable');
+    });
+
+    it('Should detect viewable state', () => {
+        let state = null;
+        state = add(state, 1, {});
+        state = loading(state, 1);
+
+        const res = get(state, 1);
+
+        assert(isViewable(res), 'resource is viewable');
+    });
+
+});


### PR DESCRIPTION
`isPending` checks whether we are waiting for data to enter the store.
This will return `false` as long as there is data to be returned,
regardless of it's state.

`isViewable` checks whether there is data in the store that can be
displayed.
This will return `true` as long as there is data to be returned,
regardless of it's state.