### PR TITLE
[page][is-ok] empty page should be OK

### DIFF
--- a/src/list/page.js
+++ b/src/list/page.js
@@ -10,7 +10,7 @@ function page(root, listName, page, opts = {}) {
     page = Math.max(0, page);
     const pages = pageCount(root, listName, opts);
 
-    if (page > pages)
+    if (page > pages && (pages != 0 || page > 1))
         return [];
 
     const list = root.list[listName];

--- a/test/status/is-ok.js
+++ b/test/status/is-ok.js
@@ -5,6 +5,7 @@ import add from '../../src/resource/add';
 import loading from '../../src/resource/loading';
 
 import getPage from '../../src/list/page';
+import options from '../../src/list/options';
 import addPage from '../../src/list/add-page';
 import loadingRange from '../../src/list/loading-range';
 
@@ -66,6 +67,35 @@ describe('# is-ok', () => {
         const res = getPage(state, 'all', 1);
 
         assert(isOk(res), 'list is OK');
+    });
+
+    it('Should read OK state from empty entry array for first page', () => {
+        let state = null;
+        state = addPage(state, 'all', 1, []);
+        state = options(state, 'all', { total: 0 });
+
+        const res = getPage(state, 'all', 1);
+
+        assert(isOk(res), 'list is OK');
+    });
+
+    it('Should read not-OK state from empty entry array for second page', () => {
+        let state = null;
+        state = addPage(state, 'all', 1, []);
+        state = options(state, 'all', { total: 0 });
+
+        const res = getPage(state, 'all', 2);
+
+        assert(!isOk(res), 'list is not-OK');
+    });
+
+    it('Should read not-OK state from empty entry array without total', () => {
+        let state = null;
+        state = addPage(state, 'all', 1, []);
+
+        const res = getPage(state, 'all', 1);
+
+        assert(!isOk(res), 'list is not OK');
     });
 
     it('Should read not-OK state from loading entry array', () => {


### PR DESCRIPTION
The first page of a collection that has no content (`total = 0`) should
return an empty array that has an OK state when checked with `isOk`.

Any other page (>1) should be considered not-OK.

Resolves https://github.com/JorgenEvens/rest-store/issues/26