### PR TITLE
fix(vuex): prevent updeep from freezing state

### DIFF
--- a/src/vuex/apply.js
+++ b/src/vuex/apply.js
@@ -1,6 +1,7 @@
 export default
 function apply(action, state, ...args) {
-    const next = action(state, ...args);
+    const root = state && Object.create(state);
+    const next = action(root, ...args);
 
     state = state || {};
     Object.assign(state, next);


### PR DESCRIPTION
When using update on state with an empty update object the state passed
in might be freezed.
This will make any attempt to `assign()` properties fail due to the
initial state being frozen. Effectively making the vuex state fully
immutable.

This is solved by passing in a very superficial clone into any operation
passed to the `apply()` function.