### PR TITLE
fix(vuex): prevent vue warnings

### DIFF
--- a/src/vuex/_get-list.js
+++ b/src/vuex/_get-list.js
@@ -1,4 +1,4 @@
-import _get from 'lodash/get';
+import _get from './_get';
 
 import getRoot from './get-root';
 import _selectors from './_selectors';

--- a/src/vuex/_get.js
+++ b/src/vuex/_get.js
@@ -1,0 +1,27 @@
+import _get from 'lodash/get';
+import _toPath from 'lodash/toPath';
+
+export
+function has(obj, keys) {
+    if (typeof keys === 'string')
+        keys = _toPath(keys);
+
+    if (keys.length < 1)
+        return true;
+
+    if (typeof obj !== 'object')
+        return false;
+
+    const key = keys[0];
+    if (key in obj)
+        return has(obj[key], keys.slice(1));
+
+    return false;
+
+}
+
+export default
+function get(obj, path) {
+    if (has(obj, path))
+        return _get(obj, path);
+}

--- a/src/vuex/_selectors.js
+++ b/src/vuex/_selectors.js
@@ -1,4 +1,4 @@
-import _get from 'lodash/get';
+import _get from './_get';
 import hash from 'hash-it';
 
 const defaultHasher = (v) => hash(v);

--- a/src/vuex/get-page.js
+++ b/src/vuex/get-page.js
@@ -1,4 +1,4 @@
-import _get from 'lodash/get';
+import _get from './_get';
 import _omit from 'lodash/omit';
 
 import shouldFetchPage from '../list/should-fetch-page';

--- a/src/vuex/get-range.js
+++ b/src/vuex/get-range.js
@@ -1,4 +1,4 @@
-import _get from 'lodash/get';
+import _get from './_get';
 
 import shouldFetchRange from '../list/should-fetch-range';
 import _transformable from './_transformable';

--- a/src/vuex/get-resource.js
+++ b/src/vuex/get-resource.js
@@ -1,4 +1,4 @@
-import _get from 'lodash/get';
+import _get from './_get';
 
 import { wrapDispatch } from '../utils/throttled-dispatch';
 import shouldFetch from '../resource/should-fetch';


### PR DESCRIPTION
Test if property exists before accessing it with lodash. We implement
this method using the `in` operator rather than use `_.has` because
lodash attempts to access `length` without checking its existence.